### PR TITLE
Refactor: Fixed Applications_controller.rb naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,7 @@ yarn-debug.log*
 # Ignore uploaded files in development
 /storage/*
 !/storage/.keep
+
+/Gemfile
+/Gemfile.lock
+/.ruby-version

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,8 @@ class ApplicationController < ActionController::Base
   def welcome
   end
 
-  def show
-    @application = Application.find(params[:id])
+  def find_pet
+    @pet = Pet.find(params[:id])
   end
 
 

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -1,0 +1,15 @@
+class ApplicationsController < ApplicationController
+
+  def show
+    @application = Application.find(params[:id])
+  end
+
+  def new
+  end
+
+  def create
+    @new_app = Application.create!(name: params[:name], street_address: params[:street_address], city: params[:city], state: params[:state], zip_code: params[:zip_code], description: "", status: "In Progress")
+    redirect_to "/applications/#{@new_app[:id]}"
+  end
+  
+end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -1,4 +1,7 @@
 class PetsController < ApplicationController
+  before_action :find_pet, only: [:show, :edit, :update]
+
+
   def index
     if params[:search].present?
       @pets = Pet.search(params[:search])
@@ -8,12 +11,12 @@ class PetsController < ApplicationController
   end
 
   def show
-    @pet = Pet.find(params[:id])
   end
 
   def new
     @shelter = Shelter.find(params[:shelter_id])
   end
+
 
   def create
     pet = Pet.new(pet_params)
@@ -27,16 +30,14 @@ class PetsController < ApplicationController
   end
 
   def edit
-    @pet = Pet.find(params[:id])
   end
 
   def update
-    pet = Pet.find(params[:id])
-    if pet.update(pet_params)
-      redirect_to "/pets/#{pet.id}"
+    if @pet.update(pet_params)
+      redirect_to "/pets/#{@pet.id}"
     else
-      redirect_to "/pets/#{pet.id}/edit"
-      flash[:alert] = "Error: #{error_message(pet.errors)}"
+      redirect_to "/pets/#{@pet.id}/edit"
+      flash[:alert] = "Error: #{error_message(@pet.errors)}"
     end
   end
 
@@ -50,4 +51,5 @@ class PetsController < ApplicationController
   def pet_params
     params.permit(:id, :name, :age, :breed, :adoptable, :shelter_id)
   end
+
 end

--- a/app/views/application/new.html.erb
+++ b/app/views/application/new.html.erb
@@ -1,0 +1,14 @@
+<%= form_with url: "/applications", method: :post, local: true do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %><br><br>
+  <%= f.label :street_address %>
+  <%= f.text_field :street_address %><br><br>
+  <%= f.label :city %>
+  <%= f.text_field :city %><br><br>
+  <%= f.label :state %>
+  <%= f.text_field :state %><br><br>
+  <%= f.label :zip_code %>
+  <%= f.text_field :zip_code %><br><br>
+
+  <%= f.submit "Create" %>
+<% end %>

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -1,5 +1,7 @@
 <h1>All pets</h1>
 
+<%= link_to "Start Application", "/applications/new" %>
+
 <%= form_with url: "/pets", method: :get, local: true do |f| %>
   <%= f.label :search %>
   <%= f.text_field :search %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   get '/', to: 'application#welcome'
-  get '/applications/:id', to: 'application#show'
+
+  get '/applications/new', to: 'applications#new'
+  post '/applications', to: 'applications#create'
+  get '/applications/:id', to: 'applications#show'
 
   get '/shelters', to: 'shelters#index'
   get '/shelters/new', to: 'shelters#new'

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe 'the application show' do
     spot = Pet.create!(adoptable: true, age: 2, breed: 'Mix', name: 'Spot', shelter_id: shelter[:id])
     application = Application.create!(name: 'Cory', city: 'Tempe', state: 'AZ', street_address: '3030 Westroad', zip_code: '85282', description: 'I love dogs and I have a lot of free time to take care of one.', status: 'Pending')
     app_pet = ApplicationPet.create!(pet_id: spot.id, application_id: application.id)
-  
+
     visit "/applications/#{application.id}"
-    save_and_open_page
+
     expect(page).to have_content(application.name)
     expect(page).to have_content(application.city)
     expect(page).to have_content(application.state)
@@ -18,4 +18,6 @@ RSpec.describe 'the application show' do
     expect(page).to have_content(application.status)
     expect(page).to have_content('Pet(s) applying for: Spot')
   end
+
+
 end


### PR DESCRIPTION
Messed up on the naming convention for the app_controller. Please pull this in to main to correct the mistake.
